### PR TITLE
fix: adds use of callback url in a deployed environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ For local development, ensure your `.env` files are configured with local URLs:
 ```env
 FRONTEND_URL=http://localhost:3000
 GITHUB_CALLBACK_URL=http://localhost:5000/auth/callback
+LOCAL_ENV=True
 ```
 
 2. **Frontend** (`frontend/.env`):

--- a/backend/config.py
+++ b/backend/config.py
@@ -36,3 +36,5 @@ class Config:
     
     # Update callback URL to be environment-aware
     GITHUB_CALLBACK_URL = os.getenv('GITHUB_CALLBACK_URL', f"{BACKEND_URL}/auth/callback")
+
+    LOCAL_ENV = os.getenv('LOCAL_ENV', False)

--- a/backend/main.py
+++ b/backend/main.py
@@ -169,8 +169,17 @@ async def submit_preference(request: Request):
 @app.get("/auth/login")
 async def github_login(request: Request, redirect_uri: str = Config.FRONTEND_URL):
     request.session['redirect_uri'] = redirect_uri
+
+    if Config.LOCAL_ENV == True:
+        return await oauth.github.authorize_redirect(
+            request, request.url_for('github_callback')
+        )
+
+    # in a deployed environment in front of nginx, the callbackURL
+    # is HTTP and we need it to be HTTPS which is why we use the
+    # CALLBACK_URL env var
     return await oauth.github.authorize_redirect(
-        request, request.url_for('github_callback')
+        request, Config.GITHUB_CALLBACK_URL
     )
 
 def is_allowed_user(username: str) -> bool:


### PR DESCRIPTION
In EC2, with ALB and Nginx container, the code seems to get a HTTP version of the callback which isn't ideal and causes CSRF concerns on Nginx resulting in logging in being unavailable. This PR ensures to use the callback url env var so that we can force it to use HTTPS.

We also add a LOCAL_ENV var so that we don't break local development.